### PR TITLE
docs: Update Schemathesis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Schemathesis is a tool which takes an OpenAPI yaml as input and test all sub-pat
 
 The function is intended to be called as cron job. Necessary environment variables are API_PATH and BASE_URL.
 
-For examples and details see [Schemathesis](https://github.com/HypothesisWorks/hypothesis)
+For examples and details see [Schemathesis](https://github.com/schemathesis/schemathesis)
 
 
 ## black_linting


### PR DESCRIPTION
Hi :) This PR updates the link to Schemathesis, so it points to its repository instead of the Hypothesis one.

P.S. Let me know if you miss any feature from the Schemathesis side - I'd be happy to collaborate :)